### PR TITLE
update scalariform

### DIFF
--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -2,4 +2,4 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.8")
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.7.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.0")


### PR DESCRIPTION
This (very useful) template resulted in unresolved dependency error: unable to find Scalariform `1.7.0` (in TC or locally) given we're using Scala `2.12` . Bumping version fixed this.

@tomrf1 