### PR TITLE
Properly configure the logger, and bump scala version

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -6,7 +6,7 @@ description:= "$project_description$"
 
 version := "1.0"
 
-scalaVersion := "2.12.2"
+scalaVersion := "2.12.8"
 
 scalacOptions ++= Seq(
   "-deprecation",
@@ -17,7 +17,8 @@ scalacOptions ++= Seq(
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "$aws_lambda_java_core_version$",
-  "org.slf4j" % "slf4j-simple" % "$slf4j_simple_version$"
+  "org.slf4j" % "slf4j-api" % "$slf4j_api_version$",
+  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "$log4j_slf4j_version$"
 )
 
 enablePlugins(RiffRaffArtifact)

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -4,4 +4,5 @@ deployBucket=$stack$-dist
 package=com.gu.$name;format="capitalize,camel"$
 project_description=CHANGE_ME
 aws_lambda_java_core_version = maven(com.amazonaws, aws-lambda-java-core)
-slf4j_simple_version = maven(org.slf4j, slf4j-simple)
+log4j_slf4j_version = maven(org.slf4j, slf4j-api)
+slf4j_api_version = maven(org.apache.logging.log4j, log4j-slf4j-impl)

--- a/src/main/g8/src/main/resources/log4j2.xml
+++ b/src/main/g8/src/main/resources/log4j2.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
+    <Appenders>
+        <Lambda name="Lambda">
+            <PatternLayout>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss} [%t] %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+            </PatternLayout>
+        </Lambda>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Lambda"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
This is a nicer way to configure the loggers for lambdas. It uses SLF4J which means all libraries should automatically bind, and uses the provided AWS logging backing through log4j 2.