### PR TITLE
Fix logging setup by pinning default versions

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -17,9 +17,9 @@ scalacOptions ++= Seq(
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "$aws_lambda_java_core_version$",
-  "com.amazonaws" % "aws-lambda-java-log4j2" % "$aws_lambda_java_log4j_version$",
-  "org.slf4j" % "slf4j-api" % "$slf4j_api_version$",
-  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "$log4j_slf4j_version$"
+  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.1.0",
+  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.8.2",
+  "org.slf4j" % "slf4j-api" % "$slf4j_api_version$"
 )
 
 enablePlugins(RiffRaffArtifact)

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -3,7 +3,5 @@ stack=CHANGE_ME
 deployBucket=$stack$-dist
 package=com.gu.$name;format="capitalize,camel"$
 project_description=CHANGE_ME
-aws_lambda_java_core_version = maven(com.amazonaws, aws-lambda-java-core)
-aws_lambda_java_log4j_version = maven(com.amazonaws, aws-lambda-java-log4j2)
-log4j_slf4j_version = maven(org.slf4j, slf4j-api)
-slf4j_api_version = maven(org.apache.logging.log4j, log4j-slf4j-impl)
+aws_lambda_java_core_version = maven(com.amazonaws, aws-lambda-java-core, stable)
+slf4j_api_version = maven(org.slf4j, slf4j-api, stable)


### PR DESCRIPTION
I had a couple of problems spinning up a new project based on this template:

1) `log4j_slf4j_version` and  `slf4j_api_version` were mixed up in the `default.properties` file - this led to problems resolving these dependencies.
2) Attempting to use a `log4j-slf4j-impl` version > `2.8.2` results in an error: `java.lang.NoClassDefFoundError: org/apache/logging/log4j/util/StackLocatorUtil`. 

I _think_ problem 2 occurs because version `1.1.0` of `aws-lambda-java-log4j2` [depends on version `2.8.2` of log4j](https://github.com/aws/aws-lambda-java-libs/tree/master/aws-lambda-java-log4j2#1-pull-in-log4j2-dependencies), so for now I've pinned the version for those two dependencies instead of trying to [fetch the latest stable version from Maven](http://www.foundweekends.org/giter8/template.html#Maven+properties). 