### PR TITLE
Allocate more memory to the lambda

### DIFF
--- a/src/main/g8/cfn.yaml
+++ b/src/main/g8/cfn.yaml
@@ -64,7 +64,7 @@ Resources:
           App: !Ref App
       Description: $project_description$
       Handler: $package$.Lambda::handler
-      MemorySize: 128
+      MemorySize: 1024
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
       Timeout: 60


### PR DESCRIPTION
In my experience this is a more appropriate default value for a lambda with `java8` runtime.