### PR TITLE
Refresh all the dependencies & Add a merge strategy for the logger

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.15
+sbt.version=1.3.13

--- a/project/giter8.sbt
+++ b/project/giter8.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.9.0")
+addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.13.1")

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,3 +1,6 @@
+import sbtassembly.AssemblyPlugin.autoImport.{assemblyJarName, assemblyMergeStrategy}
+import sbtassembly.MergeStrategy
+
 name := "$name;format="normalize"$"
 
 organization := "com.gu"
@@ -6,7 +9,7 @@ description:= "$project_description$"
 
 version := "1.0"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.3"
 
 scalacOptions ++= Seq(
   "-deprecation",
@@ -17,14 +20,19 @@ scalacOptions ++= Seq(
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "$aws_lambda_java_core_version$",
-  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.1.0",
-  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.8.2",
+  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.2.0",
+  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.13.3",
   "org.slf4j" % "slf4j-api" % "$slf4j_api_version$"
 )
 
 enablePlugins(RiffRaffArtifact)
 
 assemblyJarName := s"\${name.value}.jar"
+assemblyMergeStrategy in assembly := {
+  case "META-INF/MANIFEST.MF" => MergeStrategy.discard
+  case "META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat" => new MergeLog4j2PluginCachesStrategy
+  case _ => MergeStrategy.first
+}
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")

--- a/src/main/g8/project/MergeLog4j2PluginCachesStrategy.scala
+++ b/src/main/g8/project/MergeLog4j2PluginCachesStrategy.scala
@@ -1,0 +1,22 @@
+import java.io.ByteArrayOutputStream
+import java.nio.file.Files
+
+import org.apache.logging.log4j.core.config.plugins.processor.PluginCache
+import sbt.File
+import sbtassembly.MergeStrategy
+
+import scala.collection.JavaConverters.asJavaEnumerationConverter
+
+class MergeLog4j2PluginCachesStrategy extends MergeStrategy {
+  override def name: String = "MergeLog4j2PluginCachesStrategy"
+
+  override def apply(tempDir: File, path: String, files: Seq[File]): Either[String, Seq[(File, String)]] = {
+    val pluginCache = new PluginCache
+    pluginCache.loadCacheFiles(files.map(_.toURI.toURL).toIterator.asJavaEnumeration)
+    val baos = new ByteArrayOutputStream // avoid worrying about closeable resources
+    pluginCache.writeCache(baos)
+    val mergeFile = MergeStrategy.createMergeTarget(tempDir, path)
+    Files.write(mergeFile.toPath, baos.toByteArray)
+    Right(Seq(mergeFile -> path))
+  }
+}

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.3.13

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.8")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")


### PR DESCRIPTION
This PR bumps the various versions of each components:
 - SBT
 - Scala
 - Assembly
 - Riffraff
 - scalariform

Then I've also added a merge strategy for the log4J logger. This solves a common problem when adding the AWS sdk as a dependency, or any dependency with Log4j when packing the lambda as a big Jar.

(see https://github.com/idio/sbt-assembly-log4j2 for a good description of the issue)